### PR TITLE
Fix xchg rax rax 0x03

### DIFF
--- a/posts/2016-10-12-xchg-rax-rax-solutions.md
+++ b/posts/2016-10-12-xchg-rax-rax-solutions.md
@@ -78,7 +78,7 @@ Boolean cast: `rax := bool(rax)`, i.e. `rax := rax ? 1 : 0`.
     add      rax,rcx
 ```
 
-Minimum function: `rax := min(rax, rdx)`.
+Maximum function: `rax := max(rax, rdx)`.
 
 
 ### Snippet 0x04


### PR DESCRIPTION
The SUB instruction performs integer subtraction. It evaluates the result for both signed and unsigned integer operands and sets the OF and CF flags to indicate an overflow in the signed or unsigned result, respectively. The SF flag indicates the sign of the signed result.

Hence CF will be set when rdx > rax

if CF = 1, rcx = ffffffff ffffffff else rcx = 00000000 00000000

Hence if CF = 1, final_rax = rdx - rax + rax = rdx else final_rax  = 0 + rax = rax